### PR TITLE
Alternative to getComponentID as _rootNodeID is not longer supported on latest version of React

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -48,9 +48,6 @@ gulp.task 'testserver', connect.server
   port: 1337
   livereload: false
   middleware: -> [cors()]
-  open:
-    file: 'test/index.html'
-    browser: 'Google Chrome'
 
 # A server with another port for testing CORS
 gulp.task 'xdomainserver', connect.server

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -43,18 +43,20 @@ gulp.task 'build:tests', ->
     .pipe gulp.dest('./test/')
 
 # A server for the test page
-gulp.task 'testserver', connect.server
-  root: [__dirname]
-  port: 1337
-  livereload: false
-  middleware: -> [cors()]
+gulp.task 'testserver', ->
+  connect.server
+    root: [__dirname]
+    port: 1337
+    livereload: false
+    middleware: -> [cors()]
 
 # A server with another port for testing CORS
-gulp.task 'xdomainserver', connect.server
-  root: [__dirname]
-  port: 1338
-  livereload: false
-  middleware: -> [cors()]
+gulp.task 'xdomainserver', ->
+  connect.server
+    root: [__dirname]
+    port: 1338
+    livereload: false
+    middleware: -> [cors()]
 
 gulp.task 'test', ['build:browser', 'build:tests', 'xdomainserver', 'testserver']
 gulp.task 'build', ['build:node', 'build:browser']

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cors": "~2.2.0"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "^0.13.0-rc1"
   },
   "scripts": {
     "prepublish": "gulp build",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cors": "~2.2.0"
   },
   "peerDependencies": {
-    "react": "^0.13.0-rc1"
+    "react": "*"
   },
   "scripts": {
     "prepublish": "gulp build",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coffee-script": "~1.7.1",
     "browserify": "~3.33.0",
     "browserify-shim": "~3.3.2",
-    "gulp": "~3.5.6",
+    "gulp": "~3.8.11",
     "gulp-bump": "~0.1.6",
     "gulp-coffee": "~1.4.1",
     "gulp-util": "~2.2.14",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-coffee": "~1.4.1",
     "gulp-util": "~2.2.14",
     "gulp-browserify": "~0.5.0",
-    "gulp-connect": "~1.0.9",
+    "gulp-connect": "~2.2.0",
     "gulp-rename": "~1.2.0",
     "cors": "~2.2.0"
   },

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -95,12 +95,20 @@ uniquifyIDs = do ->
       else if p4 then "#{ p3 }=\"##{ uniquifyID p4 }\""
       else if p5 then "=\"url(##{ uniquifyID p5 })\""
 
-# Gets a unique ID for the given component, for use in the id attribute.
+# Generates a 32bit hash from the SVG path
 
-getComponentID = do ->
-  clean = (str) -> str.toString().replace /[^a-zA-Z0-9]/g, '_'
-  (component) -> "#{ clean component._rootNodeID }__#{ clean component._mountDepth }"
-
+getHash = (svgPath) ->
+  hash = 0
+  i = 0
+  char = ''
+  if svgPath.length == 0
+    return hash
+  while i < svgPath.length
+    char = svgPath.charCodeAt(i)
+    hash = (hash << 5) - hash + char
+    hash = hash & hash
+    i++
+  hash
 
 # Errors
 # ------
@@ -194,8 +202,9 @@ module.exports = me =
         @renderContents()
       )
     processSVG: (svgText) ->
-      if @props.uniquifyIDs then uniquifyIDs svgText, getComponentID this
+      if @props.uniquifyIDs then uniquifyIDs svgText, getHash @props.src
       else svgText
+
     renderContents: ->
       switch @state.status
         when Status.UNSUPPORTED then @props.children

--- a/standalone/react-inlinesvg.js
+++ b/standalone/react-inlinesvg.js
@@ -561,7 +561,7 @@ function once (fn) {
 }
 
 },{"wrappy":12}],14:[function(_dereq_,module,exports){
-var InlineSVGError, PropTypes, React, Status, configurationError, createError, delay, getComponentID, http, httpplease, ieXDomain, isSupportedEnvironment, me, once, span, supportsInlineSVG, uniquifyIDs, unsupportedBrowserError,
+var InlineSVGError, PropTypes, React, Status, configurationError, createError, delay, getHash, http, httpplease, ieXDomain, isSupportedEnvironment, me, once, span, supportsInlineSVG, uniquifyIDs, unsupportedBrowserError,
   __slice = [].slice,
   __hasProp = {}.hasOwnProperty,
   __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
@@ -636,15 +636,22 @@ uniquifyIDs = (function() {
   };
 })();
 
-getComponentID = (function() {
-  var clean;
-  clean = function(str) {
-    return str.toString().replace(/[^a-zA-Z0-9]/g, '_');
-  };
-  return function(component) {
-    return "" + (clean(component._rootNodeID)) + "__" + (clean(component._mountDepth));
-  };
-})();
+getHash = function(svgPath) {
+  var char, hash, i;
+  hash = 0;
+  i = 0;
+  char = '';
+  if (svgPath.length === 0) {
+    return hash;
+  }
+  while (i < svgPath.length) {
+    char = svgPath.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+    i++;
+  }
+  return hash;
+};
 
 InlineSVGError = (function(_super) {
   __extends(InlineSVGError, _super);
@@ -793,7 +800,7 @@ module.exports = me = React.createClass({
   },
   processSVG: function(svgText) {
     if (this.props.uniquifyIDs) {
-      return uniquifyIDs(svgText, getComponentID(this));
+      return uniquifyIDs(svgText, getHash(this.props.src));
     } else {
       return svgText;
     }

--- a/standalone/react-inlinesvg.js
+++ b/standalone/react-inlinesvg.js
@@ -503,7 +503,43 @@ module.exports = {
 };
 
 },{"../lib/utils/once":6,"urllite/lib/core":8}],12:[function(_dereq_,module,exports){
-module.exports = once
+// Returns a wrapper function that returns a wrapped callback
+// The wrapper function should do some stuff, and return a
+// presumably different callback function.
+// This makes sure that own properties are retained, so that
+// decorations and such are not lost along the way.
+module.exports = wrappy
+function wrappy (fn, cb) {
+  if (fn && cb) return wrappy(fn)(cb)
+
+  if (typeof fn !== 'function')
+    throw new TypeError('need wrapper function')
+
+  Object.keys(fn).forEach(function (k) {
+    wrapper[k] = fn[k]
+  })
+
+  return wrapper
+
+  function wrapper() {
+    var args = new Array(arguments.length)
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i]
+    }
+    var ret = fn.apply(this, args)
+    var cb = args[args.length-1]
+    if (typeof ret === 'function' && ret !== cb) {
+      Object.keys(cb).forEach(function (k) {
+        ret[k] = cb[k]
+      })
+    }
+    return ret
+  }
+}
+
+},{}],13:[function(_dereq_,module,exports){
+var wrappy = _dereq_('wrappy')
+module.exports = wrappy(once)
 
 once.proto = once(function () {
   Object.defineProperty(Function.prototype, 'once', {
@@ -524,7 +560,7 @@ function once (fn) {
   return f
 }
 
-},{}],13:[function(_dereq_,module,exports){
+},{"wrappy":12}],14:[function(_dereq_,module,exports){
 var InlineSVGError, PropTypes, React, Status, configurationError, createError, delay, getComponentID, http, httpplease, ieXDomain, isSupportedEnvironment, me, once, span, supportsInlineSVG, uniquifyIDs, unsupportedBrowserError,
   __slice = [].slice,
   __hasProp = {}.hasOwnProperty,
@@ -775,6 +811,6 @@ module.exports = me = React.createClass({
   }
 });
 
-},{"httpplease":2,"httpplease/plugins/oldiexdomain":11,"once":12}]},{},[13])
-(13)
+},{"httpplease":2,"httpplease/plugins/oldiexdomain":11,"once":13}]},{},[14])
+(14)
 });


### PR DESCRIPTION
##### Updates:
- update versions of gulp & gulp-connect (and made small code tweaks in order to support these versions)
- removing getComponentID
- adding getHash
- now its generating a hash from the SVG path instead of using getComponentID and _rootNodeID

##### Note:
Just created an small hash generator method (```getHash```), other option is to use [object-hash](https://www.npmjs.com/package/object-hash). Let me know what you think.