### PR TITLE
Add data-uri support

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -185,7 +185,14 @@ module.exports = me =
         loadedText: res.text
         status: Status.LOADED
         => @props.onLoad?()
-    load: -> http.get @props.src, @handleLoad
+    load: ->
+      if @props.src.indexOf('data:image/svg') is 0
+        # is data-uri
+        chunks = @props.src.split ';base64,'
+        @handleLoad null,
+          text: atob(chunks[1])
+      else
+        http.get @props.src, @handleLoad
     getClassName: ->
       # Build a CSS class name based on the current state.
       className = "isvg #{ @state.status }"

--- a/standalone/react-inlinesvg.js
+++ b/standalone/react-inlinesvg.js
@@ -503,7 +503,43 @@ module.exports = {
 };
 
 },{"../lib/utils/once":6,"urllite/lib/core":8}],12:[function(_dereq_,module,exports){
-module.exports = once
+// Returns a wrapper function that returns a wrapped callback
+// The wrapper function should do some stuff, and return a
+// presumably different callback function.
+// This makes sure that own properties are retained, so that
+// decorations and such are not lost along the way.
+module.exports = wrappy
+function wrappy (fn, cb) {
+  if (fn && cb) return wrappy(fn)(cb)
+
+  if (typeof fn !== 'function')
+    throw new TypeError('need wrapper function')
+
+  Object.keys(fn).forEach(function (k) {
+    wrapper[k] = fn[k]
+  })
+
+  return wrapper
+
+  function wrapper() {
+    var args = new Array(arguments.length)
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i]
+    }
+    var ret = fn.apply(this, args)
+    var cb = args[args.length-1]
+    if (typeof ret === 'function' && ret !== cb) {
+      Object.keys(cb).forEach(function (k) {
+        ret[k] = cb[k]
+      })
+    }
+    return ret
+  }
+}
+
+},{}],13:[function(_dereq_,module,exports){
+var wrappy = _dereq_('wrappy')
+module.exports = wrappy(once)
 
 once.proto = once(function () {
   Object.defineProperty(Function.prototype, 'once', {
@@ -524,7 +560,7 @@ function once (fn) {
   return f
 }
 
-},{}],13:[function(_dereq_,module,exports){
+},{"wrappy":12}],14:[function(_dereq_,module,exports){
 var InlineSVGError, PropTypes, React, Status, configurationError, createError, delay, getHash, http, httpplease, ieXDomain, isSupportedEnvironment, me, once, span, supportsInlineSVG, uniquifyIDs, unsupportedBrowserError,
   __slice = [].slice,
   __hasProp = {}.hasOwnProperty,
@@ -741,7 +777,15 @@ module.exports = me = React.createClass({
     })(this));
   },
   load: function() {
-    return http.get(this.props.src, this.handleLoad);
+    var chunks;
+    if (this.props.src.indexOf('data:image/svg') === 0) {
+      chunks = this.props.src.split(';base64,');
+      return this.handleLoad(null, {
+        text: atob(chunks[1])
+      });
+    } else {
+      return http.get(this.props.src, this.handleLoad);
+    }
   },
   getClassName: function() {
     var className;
@@ -779,6 +823,6 @@ module.exports = me = React.createClass({
   }
 });
 
-},{"httpplease":2,"httpplease/plugins/oldiexdomain":11,"once":12}]},{},[13])
-(13)
+},{"httpplease":2,"httpplease/plugins/oldiexdomain":11,"once":13}]},{},[14])
+(14)
 });

--- a/test/ic_play_arrow_24px.svg
+++ b/test/ic_play_arrow_24px.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M8 5v14l11-7z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -20,6 +20,16 @@ describe 'react-inlinesvg', ->
       src: 'tiger.svg'
       onError: done
       onLoad: -> assertContainsSvg el, done
+  it 'should load data-uri', (done) ->
+    el = renderComponent isvg
+      # Material design icon
+      # https://github.com/google/material-design-icons/blob/master/av/svg/production/ic_play_arrow_24px.svg
+      #
+      src: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGQ9Ik04IDV2MTRsMTEtN3oiLz4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KPC9zdmc+Cg=='
+      onError: done
+      onLoad: ->
+        # Make sure variable "el" is populated before assertion
+        setTimeout (-> assertContainsSvg el, done), 0
   it 'should call onError for a 404', (done) ->
     renderComponent isvg
       src: 'DOESNOTEXIST.svg'


### PR DESCRIPTION
Add support for the following syntax:

```
<isvg src="data:image/svg......." />
```

Although `xmlhttprequest` in Google Chrome & Firefox supports data-uri, the one in Safari doesn't. This pull request skips the ajax part if an SVG data-uri is given in the `src` property.