### PR TITLE
Add documentation for uniquifyIDs prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ Props
       </ul>
     </td>
   </tr>
+  <tr>
+    <td><code>uniquifyIDs</code></td>
+    <td>boolean</td>
+    <td>
+      A boolean that tells Isvg to create unique IDs for each icon by hashing it. Default is <code>true</code> but you can alter the behaviour by setting the boolean to <code>false</code>.
+
+      <code>&lt;Isvg uniquifyIDs={false}&gt;&lt;/Isvg&gt;</code>
+    </td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
This adds documentation and a code example
to the uniquifyIDs prop that defines as boolean
if to hash IDs of the icons to make them unique
or not. This closes #11.