### PR TITLE
Add react 0.14 RC to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cors": "~2.2.0"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "* || ^0.14.0-rc1"
   },
   "scripts": {
     "prepublish": "gulp build",


### PR DESCRIPTION
Because of npm's strict rule about semver ranges with prerelease versions, such versions must be added explicitly

Currently trying to install react-inlinesvg with the react 0.14 RC causes a fatal ERR in npm and sadness ensues.

This can be removed when 0.14 releases for real.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/matthewwithanm/react-inlinesvg/19)
<!-- Reviewable:end -->
