### PR TITLE
Migrated deprecated React.PropTypes to PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-util": "^3.0",
     "jsdom": "^9.6",
     "mocha": "^3.1",
+    "prop-types": "15.5.8",
     "react": "^15.3",
     "react-addons-test-utils": "^15.3",
     "react-dom": "^15.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import once from 'once';
 import httpplease from 'httpplease';
@@ -153,16 +154,16 @@ export default class InlineSVG extends React.Component {
   }
 
   static propTypes = {
-    cacheGetRequests: React.PropTypes.bool,
-    children: React.PropTypes.node,
-    className: React.PropTypes.string,
-    onError: React.PropTypes.func,
-    onLoad: React.PropTypes.func,
-    preloader: React.PropTypes.func,
-    src: React.PropTypes.string.isRequired,
-    supportTest: React.PropTypes.func,
-    uniquifyIDs: React.PropTypes.bool,
-    wrapper: React.PropTypes.func
+    cacheGetRequests: PropTypes.bool,
+    children: PropTypes.node,
+    className: PropTypes.string,
+    onError: PropTypes.func,
+    onLoad: PropTypes.func,
+    preloader: PropTypes.func,
+    src: PropTypes.string.isRequired,
+    supportTest: PropTypes.func,
+    uniquifyIDs: PropTypes.bool,
+    wrapper: PropTypes.func
   };
 
   static defaultProps = {


### PR DESCRIPTION
## Issue #56 

From now React 15.5 requires PropTypes imported from "prop-types", so we need to update to prop-types package. 

More info in official blog: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

### Tests Passing

![screen shot 2017-04-14 at 3 19 49 pm](https://cloud.githubusercontent.com/assets/381179/25054055/0fb0dcd0-2129-11e7-878d-5eea991ca630.png)

