### PR TITLE
Expanded uniquifyIDs to be able to take string as parameter, and use …

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ Props
   </tr>
   <tr>
     <td><code>uniquifyIDs</code></td>
-    <td>boolean</td>
+    <td>boolean | string</td>
     <td>
       A boolean that tells Isvg to create unique IDs for each icon by hashing it. Default is <code>true</code> but you can alter the behaviour by setting the boolean to <code>false</code>.
 
       <code>&lt;Isvg uniquifyIDs={false}&gt;&lt;/Isvg&gt;</code>
+      A string that tells Isvg to use it as postFix for each icon.
     </td>
   </tr>
   <tr>

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ export default class InlineSVG extends React.PureComponent {
     src: PropTypes.string.isRequired,
     style: PropTypes.object,
     supportTest: PropTypes.func,
-    uniquifyIDs: PropTypes.bool,
+    uniquifyIDs: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     wrapper: PropTypes.func
   };
 
@@ -259,7 +259,8 @@ export default class InlineSVG extends React.PureComponent {
 
   processSVG(svgText) {
     if (this.props.uniquifyIDs) {
-      return uniquifyIDs(svgText, getHash(this.props.src));
+      const postFix = typeof this.props.uniquifyIDs === 'string' ? this.props.uniquifyIDs : getHash(this.props.src);
+      return uniquifyIDs(svgText, postFix);
     }
 
     return svgText;


### PR DESCRIPTION
Expanded uniquifyIDs to be able to take string as parameter, and use it as is for postFix instead of hash of source file.
Hash would be fine, but working with multiple SVG images in corporation environment its more understandable to have fixed id qualifier for one image.